### PR TITLE
aiodns 3.5.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/pycares-feedstock/pr4/b2bda33
+  - https://staging.continuum.io/prefect/fs/cython-feedstock/pr26/dd0091b
+  - https://staging.continuum.io/prefect/fs/winloop-feedstock/pr1/47ba898

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/pycares-feedstock/pr4/b2bda33
+  - https://staging.continuum.io/prefect/fs/pycares-feedstock/pr4/42fe59f
   - https://staging.continuum.io/prefect/fs/cython-feedstock/pr26/dd0091b
   - https://staging.continuum.io/prefect/fs/winloop-feedstock/pr1/47ba898

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/pycares-feedstock/pr4/42fe59f
-  - https://staging.continuum.io/prefect/fs/cython-feedstock/pr26/dd0091b
-  - https://staging.continuum.io/prefect/fs/winloop-feedstock/pr1/47ba898

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - pytest tests
   requires:
     - pip
-    - pytest >8.4.1
+    - pytest
 
 about:
   home: https://github.com/aio-libs/aiodns

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,42 +1,55 @@
 {% set name = "aiodns" %}
-{% set version = "3.0.0" %}
+{% set version = "3.5.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 946bdfabe743fceeeb093c8a010f5d1645f708a241be849e17edfb0e49e08cd6
+  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 11264edbab51896ecf546c18eb0dd56dff0428c6aa6d2cd87e643e07300eb310
 
 build:
-  noarch: python
-  number: 2
-  script: "{{ PYTHON }} -m pip install . -vv"
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<39]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
-    - pycares >=4.0.0
+    - python
+    - pycares >=4.9.0
+    - uvloop >=0.21.0  # [not win]
+    - winloop >=0.1.8  # [win]
 
 test:
+  source_files:
+    - tests
   imports:
     - aiodns
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest tests
+  requires:
+    - pip
+    - pytest >8.4.1
 
 about:
-  home: https://github.com/saghul/aiodns
+  home: https://github.com/aio-libs/aiodns
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Simple DNS resolver for asyncio'
+  summary: Simple DNS resolver for asyncio
   description: |
     aiodns provides a simple way for doing asynchronous DNS resolutions using
     pycares.
-  doc_url: https://github.com/saghul/aiodns
-  dev_url: https://github.com/saghul/aiodns
+  doc_url: https://github.com/aio-libs/aiodns/blob/master/README.rst
+  dev_url: https://github.com/aio-libs/aiodns
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,8 @@ test:
     - pytest tests
   requires:
     - pip
-    - pytest
+    - pytest >=8.4.1
+    - pytest-tornasync
 
 about:
   home: https://github.com/aio-libs/aiodns


### PR DESCRIPTION
aiodns 3.5.0 

**Destination channel:** Defaults

### Links

- [PKG-9086]
- dev_url:        https://github.com/aio-libs/aiodns/tree/v3.5.0
- conda_forge:    https://github.com/conda-forge/aiodns-feedstock
- pypi:           https://pypi.org/project/aiodns/3.5.0
- pypi inspector: https://inspector.pypi.io/project/aiodns/3.5.0

### Explanation of changes:

- new version number


[PKG-9086]: https://anaconda.atlassian.net/browse/PKG-9086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ