### PR TITLE
aiodns 3.6.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiodns" %}
-{% set version = "3.5.0" %}
+{% set version = "3.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 11264edbab51896ecf546c18eb0dd56dff0428c6aa6d2cd87e643e07300eb310
+    sha256: b0e9ce98718a5b8f7ca8cd16fc393163374bc2412236b91f6c851d066e3324b6
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<39]
 
@@ -22,9 +22,9 @@ requirements:
     - wheel
   run:
     - python
-    - pycares >=4.9.0
-    - uvloop >=0.21.0  # [not win]
-    - winloop >=0.1.8  # [win]
+    - pycares >=4.9.0,<5
+    - uvloop >=0.22.1  # [not win]
+    - winloop >=0.3.1  # [win]
 
 test:
   source_files:


### PR DESCRIPTION
aiodns 3.6.1 

**Destination channel:** Defaults

### Links

- [PKG-12606]
- dev_url:        https://github.com/aio-libs/aiodns/tree/v3.6.1
- conda_forge:    https://github.com/conda-forge/aiodns-feedstock
- pypi:           https://pypi.org/project/aiodns/3.6.1
- pypi inspector: https://inspector.pypi.io/project/aiodns/3.6.1

### Explanation of changes:

- new version number


[PKG-12606]: https://anaconda.atlassian.net/browse/PKG-12606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ